### PR TITLE
Ability to override BFT

### DIFF
--- a/cba_settings_userconfig/cba_settings.sqf
+++ b/cba_settings_userconfig/cba_settings.sqf
@@ -123,7 +123,7 @@ force force ace_magazinerepack_timePerBeltLink = 8;
 force force ace_magazinerepack_timePerMagazine = 2;
 
 // ACE Map
-force force ace_map_BFT_Enabled = true;
+force ace_map_BFT_Enabled = true;
 force force ace_map_BFT_HideAiGroups = true;
 force force ace_map_BFT_Interval = 1;
 force force ace_map_BFT_ShowPlayerNames = false;


### PR DESCRIPTION
This will mean the default setting is still on and set by the server but allow mission makers to override it if their mission requires it.