### PR TITLE
v2.5.1 Update

### DIFF
--- a/cba_settings_userconfig/cba_settings.sqf
+++ b/cba_settings_userconfig/cba_settings.sqf
@@ -51,6 +51,10 @@ force force ace_captives_allowSurrender = true;
 force force ace_captives_requireSurrender = 0;
 force force ace_captives_requireSurrenderAi = false;
 
+// ACE Casings
+ace_casings_enabled = true;
+ace_casings_maxCasings = 250;
+
 // ACE Common
 force force ace_common_allowFadeMusic = true;
 force force ace_common_checkPBOsAction = 2;
@@ -62,7 +66,6 @@ ace_common_epilepsyFriendlyMode = false;
 ace_common_progressBarInfo = 2;
 ace_common_settingFeedbackIcons = 1;
 ace_common_settingProgressBarLocation = 0;
-force force ace_noradio_enabled = true;
 
 // ACE Cook off
 force force ace_cookoff_ammoCookoffDuration = 0.3;
@@ -77,6 +80,7 @@ force force ace_csw_ammoHandling = 2;
 force force ace_csw_defaultAssemblyMode = false;
 ace_csw_dragAfterDeploy = false;
 force force ace_csw_handleExtraMagazines = true;
+force ace_csw_handleExtraMagazinesType = 0;
 force force ace_csw_progressBarTimeCoefficent = 1;
 
 // ACE Dragging
@@ -232,6 +236,7 @@ ace_interact_menu_moveToRoot__ACE_Equipment__ace_interaction_weaponAttachments =
 ace_interact_menu_moveToRoot__ACE_Equipment__ace_kestrel4500_open = false;
 ace_interact_menu_moveToRoot__ACE_Equipment__ace_kestrel4500_open__ace_kestrel4500_hide = false;
 ace_interact_menu_moveToRoot__ACE_Equipment__ace_kestrel4500_open__ace_kestrel4500_show = false;
+ace_interact_menu_moveToRoot__ACE_Equipment__ace_marker_flags = false;
 ace_interact_menu_moveToRoot__ACE_Equipment__ace_microdagr_configure = false;
 ace_interact_menu_moveToRoot__ACE_Equipment__ace_microdagr_configure__ace_microdagr_close = false;
 ace_interact_menu_moveToRoot__ACE_Equipment__ace_microdagr_configure__ace_microdagr_show = false;
@@ -335,6 +340,7 @@ force force ace_repair_repairDamageThreshold_engineer = 0.4;
 force force ace_repair_wheelRepairRequiredItems = [];
 
 // ACE Magazine Repack
+ace_magazinerepack_repackAnimation = true;
 ace_magazinerepack_repackLoadedMagazines = true;
 force force ace_magazinerepack_timePerAmmo = 1.5;
 force force ace_magazinerepack_timePerBeltLink = 8;
@@ -414,6 +420,7 @@ force force ace_medical_gui_enableSelfActions = true;
 ace_medical_gui_interactionMenuShowTriage = 1;
 force force ace_medical_gui_maxDistance = 3;
 ace_medical_gui_openAfterTreatment = true;
+force ace_medical_gui_showBloodlossEntry = true;
 force force ace_medical_ivFlowRate = 2;
 force force ace_medical_limping = 1;
 force force ace_medical_painCoefficient = 1;
@@ -511,6 +518,8 @@ force force ace_finger_enabled = true;
 ace_finger_indicatorColor = [0.83,0.68,0.21,0.75];
 force force ace_finger_indicatorForSelf = true;
 force force ace_finger_maxRange = 2;
+force ace_finger_proximityScaling = false;
+force ace_finger_sizeCoef = 1;
 
 // ACE Pylons
 force force ace_pylons_enabledForZeus = true;
@@ -575,8 +584,11 @@ force force ace_gunbag_swapGunbagEnabled = true;
 force force ace_hitreactions_minDamageToTrigger = 0.1;
 ace_inventory_inventoryDisplaySize = 0;
 force force ace_laser_dispersionCount = 2;
+force ace_laser_showLaserOnMap = 1;
+force ace_marker_flags_placeAnywhere = false;
 force force ace_microdagr_mapDataAvailable = 2;
 force force ace_microdagr_waypointPrecision = 3;
+force force ace_noradio_enabled = true;
 ace_optionsmenu_showNewsOnMainMenu = true;
 force force ace_overpressure_distanceCoefficient = 1;
 force ace_parachute_failureChance = 0;
@@ -601,6 +613,7 @@ ace_ui_gunnerWeaponLowerInfoBackground = true;
 ace_ui_gunnerWeaponName = true;
 ace_ui_gunnerWeaponNameBackground = true;
 ace_ui_gunnerZeroing = true;
+ace_ui_hideDefaultActionIcon = false;
 ace_ui_magCount = true;
 ace_ui_soldierVehicleWeaponInfo = true;
 ace_ui_staminaBar = true;
@@ -630,9 +643,10 @@ force force ace_vehiclelock_vehicleStartingLockState = -1;
 ace_vehicles_hideEjectAction = true;
 force force ace_vehicles_keepEngineRunning = false;
 ace_vehicles_speedLimiterStep = 5;
+force ace_viewports_enabled = true;
 
 // ACE View Distance Limiter
-ace_viewdistance_enabled = true;
+force ace_viewdistance_enabled = true;
 force ace_viewdistance_limitViewDistance = 10000;
 ace_viewdistance_objectViewDistanceCoeff = 0;
 ace_viewdistance_viewDistanceAirVehicle = 9;

--- a/cba_settings_userconfig/cba_settings.sqf
+++ b/cba_settings_userconfig/cba_settings.sqf
@@ -80,7 +80,7 @@ force force ace_csw_ammoHandling = 2;
 force force ace_csw_defaultAssemblyMode = false;
 ace_csw_dragAfterDeploy = false;
 force force ace_csw_handleExtraMagazines = true;
-force ace_csw_handleExtraMagazinesType = 0;
+force force ace_csw_handleExtraMagazinesType = 0;
 force force ace_csw_progressBarTimeCoefficent = 1;
 
 // ACE Dragging
@@ -340,7 +340,7 @@ force force ace_repair_repairDamageThreshold_engineer = 0.4;
 force force ace_repair_wheelRepairRequiredItems = [];
 
 // ACE Magazine Repack
-ace_magazinerepack_repackAnimation = true;
+force force ace_magazinerepack_repackAnimation = true;
 ace_magazinerepack_repackLoadedMagazines = true;
 force force ace_magazinerepack_timePerAmmo = 1.5;
 force force ace_magazinerepack_timePerBeltLink = 8;
@@ -420,7 +420,7 @@ force force ace_medical_gui_enableSelfActions = true;
 ace_medical_gui_interactionMenuShowTriage = 1;
 force force ace_medical_gui_maxDistance = 3;
 ace_medical_gui_openAfterTreatment = true;
-force ace_medical_gui_showBloodlossEntry = true;
+force force ace_medical_gui_showBloodlossEntry = true;
 force force ace_medical_ivFlowRate = 2;
 force force ace_medical_limping = 1;
 force force ace_medical_painCoefficient = 1;
@@ -518,8 +518,8 @@ force force ace_finger_enabled = true;
 ace_finger_indicatorColor = [0.83,0.68,0.21,0.75];
 force force ace_finger_indicatorForSelf = true;
 force force ace_finger_maxRange = 2;
-force ace_finger_proximityScaling = false;
-force ace_finger_sizeCoef = 1;
+force force ace_finger_proximityScaling = false;
+force force ace_finger_sizeCoef = 1;
 
 // ACE Pylons
 force force ace_pylons_enabledForZeus = true;
@@ -584,8 +584,8 @@ force force ace_gunbag_swapGunbagEnabled = true;
 force force ace_hitreactions_minDamageToTrigger = 0.1;
 ace_inventory_inventoryDisplaySize = 0;
 force force ace_laser_dispersionCount = 2;
-force ace_laser_showLaserOnMap = 1;
-force ace_marker_flags_placeAnywhere = false;
+force force ace_laser_showLaserOnMap = 1;
+force force ace_marker_flags_placeAnywhere = false;
 force force ace_microdagr_mapDataAvailable = 2;
 force force ace_microdagr_waypointPrecision = 3;
 force force ace_noradio_enabled = true;
@@ -643,10 +643,10 @@ force force ace_vehiclelock_vehicleStartingLockState = -1;
 ace_vehicles_hideEjectAction = true;
 force force ace_vehicles_keepEngineRunning = false;
 ace_vehicles_speedLimiterStep = 5;
-force ace_viewports_enabled = true;
+force force ace_viewports_enabled = true;
 
 // ACE View Distance Limiter
-force ace_viewdistance_enabled = true;
+ace_viewdistance_enabled = true;
 force ace_viewdistance_limitViewDistance = 10000;
 ace_viewdistance_objectViewDistanceCoeff = 0;
 ace_viewdistance_viewDistanceAirVehicle = 9;

--- a/cba_settings_userconfig/defaults.sqf
+++ b/cba_settings_userconfig/defaults.sqf
@@ -51,6 +51,10 @@ force ace_captives_allowSurrender = true;
 force ace_captives_requireSurrender = 1;
 force ace_captives_requireSurrenderAi = false;
 
+// ACE Casings
+ace_casings_enabled = true;
+ace_casings_maxCasings = 250;
+
 // ACE Common
 force ace_common_allowFadeMusic = true;
 force ace_common_checkPBOsAction = 0;
@@ -62,7 +66,6 @@ ace_common_epilepsyFriendlyMode = false;
 ace_common_progressBarInfo = 2;
 ace_common_settingFeedbackIcons = 1;
 ace_common_settingProgressBarLocation = 0;
-force ace_noradio_enabled = true;
 
 // ACE Cook off
 force ace_cookoff_ammoCookoffDuration = 1;
@@ -77,6 +80,7 @@ force ace_csw_ammoHandling = 2;
 force ace_csw_defaultAssemblyMode = false;
 ace_csw_dragAfterDeploy = false;
 force ace_csw_handleExtraMagazines = true;
+force ace_csw_handleExtraMagazinesType = 0;
 force ace_csw_progressBarTimeCoefficent = 1;
 
 // ACE Dragging
@@ -232,6 +236,7 @@ ace_interact_menu_moveToRoot__ACE_Equipment__ace_interaction_weaponAttachments =
 ace_interact_menu_moveToRoot__ACE_Equipment__ace_kestrel4500_open = false;
 ace_interact_menu_moveToRoot__ACE_Equipment__ace_kestrel4500_open__ace_kestrel4500_hide = false;
 ace_interact_menu_moveToRoot__ACE_Equipment__ace_kestrel4500_open__ace_kestrel4500_show = false;
+ace_interact_menu_moveToRoot__ACE_Equipment__ace_marker_flags = false;
 ace_interact_menu_moveToRoot__ACE_Equipment__ace_microdagr_configure = false;
 ace_interact_menu_moveToRoot__ACE_Equipment__ace_microdagr_configure__ace_microdagr_close = false;
 ace_interact_menu_moveToRoot__ACE_Equipment__ace_microdagr_configure__ace_microdagr_show = false;
@@ -335,6 +340,7 @@ force ace_repair_repairDamageThreshold_engineer = 0.4;
 force ace_repair_wheelRepairRequiredItems = [];
 
 // ACE Magazine Repack
+ace_magazinerepack_repackAnimation = true;
 ace_magazinerepack_repackLoadedMagazines = true;
 force ace_magazinerepack_timePerAmmo = 1.5;
 force ace_magazinerepack_timePerBeltLink = 8;
@@ -414,6 +420,7 @@ ace_medical_gui_enableSelfActions = true;
 ace_medical_gui_interactionMenuShowTriage = 1;
 force ace_medical_gui_maxDistance = 3;
 ace_medical_gui_openAfterTreatment = true;
+force ace_medical_gui_showBloodlossEntry = true;
 force ace_medical_ivFlowRate = 1;
 force ace_medical_limping = 1;
 force ace_medical_painCoefficient = 1;
@@ -511,6 +518,8 @@ force ace_finger_enabled = false;
 ace_finger_indicatorColor = [0.83,0.68,0.21,0.75];
 ace_finger_indicatorForSelf = true;
 force ace_finger_maxRange = 4;
+force ace_finger_proximityScaling = false;
+force ace_finger_sizeCoef = 1;
 
 // ACE Pylons
 force ace_pylons_enabledForZeus = true;
@@ -575,8 +584,11 @@ force ace_gunbag_swapGunbagEnabled = true;
 force ace_hitreactions_minDamageToTrigger = 0.1;
 ace_inventory_inventoryDisplaySize = 0;
 force ace_laser_dispersionCount = 2;
+force ace_laser_showLaserOnMap = 1;
+force ace_marker_flags_placeAnywhere = false;
 force ace_microdagr_mapDataAvailable = 2;
 force ace_microdagr_waypointPrecision = 3;
+force ace_noradio_enabled = true;
 ace_optionsmenu_showNewsOnMainMenu = true;
 force ace_overpressure_distanceCoefficient = 1;
 force ace_parachute_failureChance = 0;
@@ -601,6 +613,7 @@ ace_ui_gunnerWeaponLowerInfoBackground = true;
 ace_ui_gunnerWeaponName = true;
 ace_ui_gunnerWeaponNameBackground = true;
 ace_ui_gunnerZeroing = true;
+ace_ui_hideDefaultActionIcon = false;
 ace_ui_magCount = true;
 ace_ui_soldierVehicleWeaponInfo = true;
 ace_ui_staminaBar = true;
@@ -630,6 +643,7 @@ force ace_vehiclelock_vehicleStartingLockState = -1;
 ace_vehicles_hideEjectAction = true;
 force ace_vehicles_keepEngineRunning = false;
 ace_vehicles_speedLimiterStep = 5;
+force ace_viewports_enabled = true;
 
 // ACE View Distance Limiter
 force ace_viewdistance_enabled = true;


### PR DESCRIPTION
Our CBA server settings and default config files have received updates in line with the latest ACE3 v3.15.0. fixes #69


## CBA Server Settings

### ACE Casings

ADDED:

``` sqf
ace_casings_enabled = true;
ace_casings_maxCasings = 250;
```

A new ACE3 v3.15.0 setting: enables bullet casings. recommend keeping enforcement as is, since this can have a performance impact on users. Players should be able to tweak this setting to save frames.

---

### ACE Common

REMOVED:

``` sqf
force force ace_noradio_enabled = true;
```

Setting was moved from `// ACE Common` to `// ACE Uncategorized` (see below).

---

### ACE Crew Served Weapons

ADDED:

``` sqf
force force ace_csw_handleExtraMagazinesType = 0;
```

A new ACE3 v3.15.0 setting: Ammo Storage (determines whether extra magazines are stored on the ground or inside an ammo box). Recommend keeping the default setting `0` (ground) but set enforcement from `force` to `force force` to match our enforcement settings in the same category.

---

### ACE Interaction Menu (Self) - Move to Root

ADDED:

``` sqf
ace_interact_menu_moveToRoot__ACE_Equipment__ace_marker_flags = false;
```

A new ACE3 v3.15.0 setting. recommend keeping enforcement as is, since we don't enforce this category for similar settings.

---

### ACE Magazine Repack

ADDED:

``` sqf
force force ace_magazinerepack_repackAnimation = true;
```

A new ACE3 v3.15.0 setting: animation for repacking magazines. Recommend keeping the default setting `true` but set enforcement from `none` to `force force` to match our enforcement settings in the same category.

---

### ACE Medical

ADDED:

``` sqf
force force ace_medical_gui_showBloodlossEntry = true;
```

A new ACE3 v3.15.0 setting: shows qualitative blood loss in the injury list. Recommend keeping the default setting `true` but set enforcement from `force` to `force force` to match our enforcement settings in the same category.

---

### ACE Pointing

ADDED:

``` sqf
force forceace_finger_proximityScaling = false;
force force ace_finger_sizeCoef = 1;
```

New ACE3 v3.15.0 settings. Recommend keeping the default settings `false` and `1`  but set enforcement from `force` to `force force` to match our enforcement settings in the same category.

---

### ACE Uncategorized

ADDED:

``` sqf
force force ace_laser_showLaserOnMap = 1;
force force ace_marker_flags_placeAnywhere = false;
force force ace_noradio_enabled = true;
```

New ACE3 v3.15.0 settings. Recommend keeping the default settings `1`, `false` and `true`  but set enforcement from `force` to `force force` to match our enforcement settings in the same category.

---

### ACE User Interface

ADDED:

``` sqf
ace_ui_hideDefaultActionIcon = false;
```

A new ACE3 v3.15.0 setting. recommend keeping enforcement as is, since we don't enforce this category for similar settings.

---

### ACE Vehicles

ADDED:

``` sqf
force force ace_viewports_enabled = true;
```

New ACE3 v3.15.0 settings. Allows crew to look through periscopes. Recommend keeping the default settings `true`  but set enforcement from `force` to `force force` to match our enforcement settings in the same category.

---

### ACE View Distance Limiter

UPDATED:

``` sqf
ace_viewdistance_enabled = true;
```

ACE3 changed their default enforcement from `none` to `force`. I recommend changing this back to `none` as players should have options how they would like to handle view distance since it impacts performance greatly and some may prefer the vanilla options of setting view distance (though I can't imagine a good reason why - I also don't see a reason for enforcing this mission or server-wide).

---

## CBA Default Settings

Pulled the latest mod default configs for ACE3 v3.15.0 via Freghar's script.