### PR TITLE
v2.5.3 Update

### DIFF
--- a/cba_settings_userconfig/cba_settings.sqf
+++ b/cba_settings_userconfig/cba_settings.sqf
@@ -72,7 +72,7 @@ ace_common_settingProgressBarLocation = 0;
 
 // ACE Cook off
 force force ace_cookoff_ammoCookoffDuration = 0.3;
-force ace_cookoff_destroyVehicleAfterCookoff = false;
+force force ace_cookoff_destroyVehicleAfterCookoff = false;
 force force ace_cookoff_enable = 0;
 force force ace_cookoff_enableAmmobox = true;
 force force ace_cookoff_enableAmmoCookoff = true;
@@ -328,7 +328,7 @@ force force ace_rearm_distance = 20;
 force force ace_rearm_level = 1;
 force force ace_rearm_supply = 0;
 force force ace_refuel_hoseLength = 12;
-force ace_refuel_progressDuration = 2;
+force force ace_refuel_progressDuration = 2;
 force force ace_refuel_rate = 1;
 force force ace_repair_addSpareParts = true;
 force force ace_repair_autoShutOffEngineWhenStartingRepair = true;
@@ -344,7 +344,7 @@ force force ace_repair_miscRepairRequiredItems = ["ace_repair_anyToolKit"];
 force force ace_repair_repairDamageThreshold = 0.6;
 force force ace_repair_repairDamageThreshold_engineer = 0.4;
 force force ace_repair_wheelRepairRequiredItems = [];
-force ace_towing_addRopeToVehicleInventory = true;
+force force ace_towing_addRopeToVehicleInventory = false;
 
 // ACE Magazine Repack
 force force ace_magazinerepack_repackAnimation = true;
@@ -654,7 +654,7 @@ ace_vehicles_speedLimiterStep = 5;
 force force ace_viewports_enabled = true;
 
 // ACE View Distance Limiter
-force ace_viewdistance_enabled = true;
+ace_viewdistance_enabled = true;
 force ace_viewdistance_limitViewDistance = 10000;
 ace_viewdistance_objectViewDistanceCoeff = 0;
 ace_viewdistance_viewDistanceAirVehicle = 9;

--- a/cba_settings_userconfig/cba_settings.sqf
+++ b/cba_settings_userconfig/cba_settings.sqf
@@ -36,6 +36,9 @@ force force ace_arsenal_enableIdentityTabs = true;
 ace_arsenal_enableModIcons = true;
 ace_arsenal_EnableRPTLog = false;
 ace_arsenal_fontHeight = 4.5;
+ace_arsenal_loadoutsSaveFace = false;
+ace_arsenal_loadoutsSaveInsignia = true;
+ace_arsenal_loadoutsSaveVoice = false;
 
 // ACE Artillery
 force force ace_artillerytables_advancedCorrections = false;
@@ -69,6 +72,7 @@ ace_common_settingProgressBarLocation = 0;
 
 // ACE Cook off
 force force ace_cookoff_ammoCookoffDuration = 0.3;
+force ace_cookoff_destroyVehicleAfterCookoff = false;
 force force ace_cookoff_enable = 0;
 force force ace_cookoff_enableAmmobox = true;
 force force ace_cookoff_enableAmmoCookoff = true;
@@ -314,6 +318,7 @@ ace_interact_menu_moveToRoot__SSS_main__SSS_logistics = false;
 ace_interact_menu_moveToRoot__SSS_main__SSS_transport = false;
 
 // ACE Logistics
+ace_cargo_carryAfterUnload = true;
 force force ace_cargo_enable = true;
 force force ace_cargo_enableRename = false;
 force force ace_cargo_loadTimeCoefficient = 5;
@@ -323,6 +328,7 @@ force force ace_rearm_distance = 20;
 force force ace_rearm_level = 1;
 force force ace_rearm_supply = 0;
 force force ace_refuel_hoseLength = 12;
+force ace_refuel_progressDuration = 2;
 force force ace_refuel_rate = 1;
 force force ace_repair_addSpareParts = true;
 force force ace_repair_autoShutOffEngineWhenStartingRepair = true;
@@ -338,6 +344,7 @@ force force ace_repair_miscRepairRequiredItems = ["ace_repair_anyToolKit"];
 force force ace_repair_repairDamageThreshold = 0.6;
 force force ace_repair_repairDamageThreshold_engineer = 0.4;
 force force ace_repair_wheelRepairRequiredItems = [];
+force ace_towing_addRopeToVehicleInventory = true;
 
 // ACE Magazine Repack
 force force ace_magazinerepack_repackAnimation = true;
@@ -640,13 +647,14 @@ force force ace_vehiclelock_lockVehicleInventory = true;
 force force ace_vehiclelock_vehicleStartingLockState = -1;
 
 // ACE Vehicles
+force ace_novehicleclanlogo_enabled = false;
 ace_vehicles_hideEjectAction = true;
 force force ace_vehicles_keepEngineRunning = false;
 ace_vehicles_speedLimiterStep = 5;
 force force ace_viewports_enabled = true;
 
 // ACE View Distance Limiter
-ace_viewdistance_enabled = true;
+force ace_viewdistance_enabled = true;
 force ace_viewdistance_limitViewDistance = 10000;
 ace_viewdistance_objectViewDistanceCoeff = 0;
 ace_viewdistance_viewDistanceAirVehicle = 9;

--- a/cba_settings_userconfig/defaults.sqf
+++ b/cba_settings_userconfig/defaults.sqf
@@ -25,7 +25,7 @@ ace_advanced_throwing_showThrowArc = true;
 
 // ACE Advanced Vehicle Damage
 force ace_vehicle_damage_enableCarDamage = false;
-force ace_vehicle_damage_enabled = true;
+force ace_vehicle_damage_enabled = false;
 force ace_vehicle_damage_removeAmmoDuringCookoff = true;
 
 // ACE Arsenal
@@ -36,6 +36,9 @@ force ace_arsenal_enableIdentityTabs = true;
 ace_arsenal_enableModIcons = true;
 ace_arsenal_EnableRPTLog = false;
 ace_arsenal_fontHeight = 4.5;
+ace_arsenal_loadoutsSaveFace = false;
+ace_arsenal_loadoutsSaveInsignia = true;
+ace_arsenal_loadoutsSaveVoice = false;
 
 // ACE Artillery
 force ace_artillerytables_advancedCorrections = false;
@@ -69,6 +72,7 @@ ace_common_settingProgressBarLocation = 0;
 
 // ACE Cook off
 force ace_cookoff_ammoCookoffDuration = 1;
+force ace_cookoff_destroyVehicleAfterCookoff = false;
 force ace_cookoff_enable = 2;
 force ace_cookoff_enableAmmobox = true;
 force ace_cookoff_enableAmmoCookoff = true;
@@ -314,6 +318,7 @@ ace_interact_menu_moveToRoot__SSS_main__SSS_logistics = false;
 ace_interact_menu_moveToRoot__SSS_main__SSS_transport = false;
 
 // ACE Logistics
+ace_cargo_carryAfterUnload = true;
 force ace_cargo_enable = true;
 ace_cargo_enableRename = true;
 force ace_cargo_loadTimeCoefficient = 5;
@@ -323,6 +328,7 @@ force ace_rearm_distance = 20;
 force ace_rearm_level = 0;
 force ace_rearm_supply = 0;
 force ace_refuel_hoseLength = 12;
+force ace_refuel_progressDuration = 2;
 force ace_refuel_rate = 1;
 force ace_repair_addSpareParts = true;
 force ace_repair_autoShutOffEngineWhenStartingRepair = false;
@@ -338,6 +344,7 @@ force ace_repair_miscRepairRequiredItems = ["ace_repair_anyToolKit"];
 force ace_repair_repairDamageThreshold = 0.6;
 force ace_repair_repairDamageThreshold_engineer = 0.4;
 force ace_repair_wheelRepairRequiredItems = [];
+force ace_towing_addRopeToVehicleInventory = true;
 
 // ACE Magazine Repack
 ace_magazinerepack_repackAnimation = true;
@@ -640,6 +647,7 @@ force ace_vehiclelock_lockVehicleInventory = false;
 force ace_vehiclelock_vehicleStartingLockState = -1;
 
 // ACE Vehicles
+force ace_novehicleclanlogo_enabled = false;
 ace_vehicles_hideEjectAction = true;
 force ace_vehicles_keepEngineRunning = false;
 ace_vehicles_speedLimiterStep = 5;


### PR DESCRIPTION
Our CBA server settings and default config files have received updates in line with the latest ACE3 update. fixes #73  


## CBA Server Settings

### ACE Arsenal

ADDED:

``` sqf
ace_arsenal_loadoutsSaveFace = false;
ace_arsenal_loadoutsSaveInsignia = true;
ace_arsenal_loadoutsSaveVoice = false;
```

Added new default settings for ACE3 Arsenal.

---

### ACE Cook off

ADDED:

``` sqf
force force ace_cookoff_destroyVehicleAfterCookoff = false;
```

Changed enforcement from `force` to `force force` in line with the rest of the enforcements in the same ACE3 category.

---

### ACE Logistics

ADDED:

``` sqf
ace_cargo_carryAfterUnload = true;
force force ace_refuel_progressDuration = 2;
force force ace_towing_addRopeToVehicleInventory = false;
```

Changed enforcement from `force` to `force force` for `ace_refuel_progressDuration` in line with the rest of the enforcements in the same ACE3 category.

Changed enforcement from `force` to `force force` for `ace_towing_addRopeToVehicleInventory` in line with the rest of the enforcements in the same ACE3 category and set the value from `true` to `false` since Arma Additions would clean out the vic inventory anyways thus saving us a bit of server CPU.

---

### ACE Vehicles

ADDED:

``` sqf
force ace_novehicleclanlogo_enabled = false;
```

Added new default settings for ACE3 Arsenal.

---

## CBA Default Settings

Pulled the latest mod default configs for ACE3 v3.15.1 via Freghar's script.